### PR TITLE
This is useful for the Android Lint usage of Lombok.AST

### DIFF
--- a/src/main/lombok/ast/AbstractNode.java
+++ b/src/main/lombok/ast/AbstractNode.java
@@ -31,16 +31,19 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ast.printer.SourcePrinter;
 import lombok.ast.printer.TextFormatter;
 
 abstract class AbstractNode implements Node {
-	@Getter private Position position = Position.UNPLACED;
+	private Position position = Position.UNPLACED;
 	@Getter private Node parent;
 	private List<Node> danglings;
 	private Map<String, Position> conversionPositions;
 	private Map<MessageKey, Message> messagesMap;
 	private List<Message> messages;
+	@Getter @Setter private Object nativeNode;
+	@Getter @Setter private PositionFactory positionFactory;
 	
 	@Override public boolean isGenerated() {
 		return position.getGeneratedBy() != null;
@@ -122,7 +125,14 @@ abstract class AbstractNode implements Node {
 		this.position = position;
 		return this;
 	}
-	
+
+	@Override public Position getPosition() {
+		if (position == Position.UNPLACED && positionFactory != null) {
+			position = positionFactory.getPosition(this);
+		}
+		return position;
+	}
+
 	@Override public String toString() {
 		TextFormatter formatter = new TextFormatter();
 		SourcePrinter printer = new SourcePrinter(formatter);

--- a/src/main/lombok/ast/Node.java
+++ b/src/main/lombok/ast/Node.java
@@ -91,4 +91,43 @@ public interface Node {
 	boolean hasMessage(String key);
 	
 	List<Message> getMessages();
+	
+	/**
+	 * Gets the associated "native" node. If this Lombok AST was created as
+	 * a transformation from another AST, such as the ECJ one, the corresponding
+	 * ECJ node can be stored here. This can be used by the {@link PositionFactory}
+	 * to lazily compute positions, or by a type resolver to perform type resolution
+	 * also using the native data structures.
+	 *
+	 * @return the corresponding native node, or null if not set
+	 */
+	Object getNativeNode();
+	
+	/**
+	 * Sets the associated "native" node. See {@link #getNativeNode()} for details.
+	 *
+	 * @param node the native node to associate with this Lombok AST node
+	 */
+	void setNativeNode(Object node);
+	
+	/**
+	 * Gets the position factory associated with this node. See
+	 * {@link #setPositionFactory(PositionFactory)} for details
+	 *
+	 * @return the position factory, or null if not set
+	 */
+	PositionFactory getPositionFactory();
+	
+	/**
+	 * Sets the {@link PositionFactory} associated with nodes of this type.
+	 * This allows the {@link #getPosition()} method to lazily create {@link Position}
+	 * objects from the {@link #getNativeNode()} instances. The native nodes
+	 * can be used for other purposes too, such as type resolution, but the
+	 * position factory is stored directly on the node such that it can make
+	 * the {@link #getPosition()} method use it transparently without the client
+	 * needing to pass the node to an external helper
+	 *
+	 * @param factory the factory to use to get positions for the current node
+	 */
+	void setPositionFactory(PositionFactory factory);
 }

--- a/src/main/lombok/ast/PositionFactory.java
+++ b/src/main/lombok/ast/PositionFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2013 The Project Lombok Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.ast;
+
+/** A factory which can create position information for nodes */
+public class PositionFactory {
+    /** Returns the {@link Position} corresponding to the given node */
+    public Position getPosition(Node node) {
+        return null;
+    }
+}

--- a/src/main/lombok/ast/grammar/TemporaryNodes.java
+++ b/src/main/lombok/ast/grammar/TemporaryNodes.java
@@ -30,6 +30,7 @@ import lombok.ast.AstVisitor;
 import lombok.ast.Message;
 import lombok.ast.Node;
 import lombok.ast.Position;
+import lombok.ast.PositionFactory;
 
 abstract class TemporaryNode implements Node {
 	private Position position = Position.UNPLACED;
@@ -124,5 +125,23 @@ abstract class TemporaryNode implements Node {
 	
 	@Override public Node getParent() {
 		return null;
+	}
+	
+	@Override
+	public Object getNativeNode() {
+		return null;
+	}
+	
+	@Override
+	public void setNativeNode(Object node) {
+	}
+	
+	@Override
+	public PositionFactory getPositionFactory() {
+		return null;
+	}
+	
+	@Override
+	public void setPositionFactory(PositionFactory positionFactory) {
 	}
 }


### PR DESCRIPTION
The native node field (a plain Object) is available for the
AST converters to keep a reference to the original AST node
corresponding to the Lombok node. This node can then be used
later to do type resolution (using a type helper, specific to
each AST, which casts the native nodes back and performs
AST specific logi).

It can also be used to lazily compute positions. This is useful
for lint, where a lot of node information is unused. In order
to make this work without an external helper, it also stashes
a reference to a PositionFactory, supplied by the AST
transformer, which lazily creates Position objects on the fly.
